### PR TITLE
Refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pachun/react-native-use-app-lifecycle",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "license": "MIT",
   "description": "React Native hook to run onLaunch, onFocus and onBlur callbacks",
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,38 +1,20 @@
-// lines marked "unappealing" exist for testing purposes
-// We don't love them, but they're the best way we've found to test the useAppLifecycle hook
-
 import React from "react"
 import { AppState, AppStateStatus } from "react-native"
+import onStateChange from "./onStateChange"
 
-type onLaunch = (() => void) | (() => Promise<void>)
-type onFocus = (() => void) | (() => Promise<void>)
-type onBlur = (() => void) | (() => Promise<void>)
-type onStateChange = (
-  previousAppState: AppStateStatus,
-) => (currentAppState: AppStateStatus) => void
+export type OnLaunch = (() => void) | (() => Promise<void>)
+export type OnFocus = (() => void) | (() => Promise<void>)
+export type OnBlur = (() => void) | (() => Promise<void>)
 
-const isFocused = (appState: string): boolean => {
-  return appState === "active"
-}
-
-const isBlurred = (appState: string): boolean => {
-  return appState === "inactive" || appState === "background"
-}
-
-const useAppLifecycle = (
-  {
-    onLaunch,
-    onFocus,
-    onBlur,
-  }: {
-    onLaunch?: onLaunch
-    onFocus?: onFocus
-    onBlur?: onBlur
-  },
-  // unappealing start
-  injectedOnStateChangeForTesting?: onStateChange,
-  // unappealing end
-) => {
+const useAppLifecycle = ({
+  onLaunch,
+  onFocus,
+  onBlur,
+}: {
+  onLaunch?: OnLaunch
+  onFocus?: OnFocus
+  onBlur?: OnBlur
+}) => {
   const [hasLaunched, setHasLaunched] = React.useState(false)
 
   React.useEffect(() => {
@@ -46,51 +28,15 @@ const useAppLifecycle = (
     React.useState<AppStateStatus>(AppState.currentState)
 
   React.useEffect(() => {
-    const onStateChange =
-      (previousAppState: AppStateStatus) =>
-      (currentAppState: AppStateStatus) => {
-        if (
-          onFocus &&
-          isBlurred(previousAppState) &&
-          isFocused(currentAppState)
-        ) {
-          onFocus()
-        }
-
-        if (
-          onBlur &&
-          isFocused(previousAppState) &&
-          isBlurred(currentAppState)
-        ) {
-          onBlur()
-        }
-
-        setPreviousAppState(currentAppState)
-      }
-
-    // unappealing start
-    if (__DEV__) {
-      ;(global as any).onStateChange = onStateChange
-    }
-    // unappealing end
-
     const subscription = AppState.addEventListener(
       "change",
-      // unappealing start
-      injectedOnStateChangeForTesting ?? onStateChange(previousAppState),
-      // unappealing end
+      onStateChange(previousAppState, setPreviousAppState, onFocus, onBlur),
     )
 
     return () => {
       subscription.remove()
-
-      // unappealing start
-      if (__DEV__) {
-        delete (global as any).onStateChange
-      }
-      // unappealing end
     }
-  }, [onFocus, onBlur, previousAppState, injectedOnStateChangeForTesting])
+  }, [onFocus, onBlur, previousAppState])
 }
 
 export default useAppLifecycle

--- a/src/onStateChange.ts
+++ b/src/onStateChange.ts
@@ -1,0 +1,31 @@
+import { AppStateStatus } from "react-native"
+import { OnBlur, OnFocus } from "./index"
+
+const isFocused = (appState: AppStateStatus): boolean => {
+  return appState === "active"
+}
+
+const isBlurred = (appState: AppStateStatus): boolean => {
+  return appState === "inactive" || appState === "background"
+}
+
+const onStateChange =
+  (
+    previousAppState: AppStateStatus,
+    setPreviousAppState: React.Dispatch<React.SetStateAction<AppStateStatus>>,
+    onFocus?: OnFocus,
+    onBlur?: OnBlur,
+  ) =>
+  (currentAppState: AppStateStatus) => {
+    if (onFocus && isBlurred(previousAppState) && isFocused(currentAppState)) {
+      onFocus()
+    }
+
+    if (onBlur && isFocused(previousAppState) && isBlurred(currentAppState)) {
+      onBlur()
+    }
+
+    setPreviousAppState(currentAppState)
+  }
+
+export default onStateChange

--- a/tests/onStateChange.test.ts
+++ b/tests/onStateChange.test.ts
@@ -1,0 +1,39 @@
+import onStateChange from "../src/onStateChange"
+
+describe("onStateChange", () => {
+  it("calls onFocus when the app is focused (and saves the previous state)", async () => {
+    const setPreviousAppState = jest.fn()
+    const onFocus = jest.fn()
+    const onBlur = jest.fn()
+
+    onStateChange("inactive", setPreviousAppState, onFocus, onBlur)("active")
+
+    expect(onFocus).toHaveBeenCalledTimes(1)
+    expect(setPreviousAppState).toHaveBeenNthCalledWith(1, "active")
+
+    onStateChange("background", setPreviousAppState, onFocus, onBlur)("active")
+
+    expect(onFocus).toHaveBeenCalledTimes(2)
+    expect(setPreviousAppState).toHaveBeenNthCalledWith(2, "active")
+
+    expect(onBlur).not.toHaveBeenCalled()
+  })
+
+  it("calls onBlur when the app is blurred (and saves the previous state)", async () => {
+    const setPreviousAppState = jest.fn()
+    const onFocus = jest.fn()
+    const onBlur = jest.fn()
+
+    onStateChange("active", setPreviousAppState, onFocus, onBlur)("background")
+
+    expect(onBlur).toHaveBeenCalledTimes(1)
+    expect(setPreviousAppState).toHaveBeenNthCalledWith(1, "background")
+
+    onStateChange("active", setPreviousAppState, onFocus, onBlur)("inactive")
+
+    expect(onBlur).toHaveBeenCalledTimes(2)
+    expect(setPreviousAppState).toHaveBeenNthCalledWith(2, "inactive")
+
+    expect(onFocus).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Avoid assigning attributes to global in order to test them.

Aside from one test which obviously got tougher to read, I believe the test suite and package code are easier to read.